### PR TITLE
BTPROTO_L2CAP extenstion: Expand the docs & provide link targets for the constants

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -137,10 +137,16 @@ created.  Socket addresses are represented as follows:
 - :const:`AF_BLUETOOTH` supports the following protocols and address
   formats:
 
-  - :const:`BTPROTO_L2CAP` accepts ``(bdaddr, psm, cid, bdaddr_type)`` where ``bdaddr`` is
-    the Bluetooth address as a string and ``psm``, ``cid`` and ``bdaddr_type`` are integers.
-    ``cid`` and ``bdaddr_type`` are optional. ``bdaddr_type`` should be one of :const:`BDADDR_BREDR`,
-    :const:`BDADDR_LE_PUBLIC`, :const:`BDADDR_LE_RANDOM`.
+  - :const:`BTPROTO_L2CAP` accepts a tuple
+    ``(bdaddr, psm[, cid[, bdaddr_type]])`` where:
+
+    - ``bdaddr``: String specifying the Bluetooth address.
+    - ``psm`` Integer specifying the Protocol/Service Multiplexer.
+    - ``cid`` Optional integer specifying the Channel Identifier. If not given,
+      defaults to zero.
+    - ``bdaddr_type`` Optional integer specifying the address type;
+      one of :const:`BDADDR_BREDR` (default), :const:`BDADDR_LE_PUBLIC`,
+      :const:`BDADDR_LE_RANDOM`.
 
     .. versionchanged:: next
       Added ``cid`` and ``bdaddr_type`` fields.
@@ -631,6 +637,14 @@ Constants
    This constant contains a boolean value which indicates if IPv6 is supported on
    this platform.
 
+.. data:: AF_BLUETOOTH
+          BTPROTO_L2CAP
+          BTPROTO_RFCOMM
+          BTPROTO_HCI
+          BTPROTO_SCO
+
+   Integer constants for use with Bluetooth addresses.
+
 .. data:: BDADDR_ANY
           BDADDR_LOCAL
 
@@ -643,7 +657,8 @@ Constants
           BDADDR_LE_PUBLIC
           BDADDR_LE_RANDOM
 
-    These constants describe the Bluetooth address type when binding or connecting a :const:`BTPROTO_L2CAP` socket.
+   These constants describe the Bluetooth address type when binding or
+   connecting a :const:`BTPROTO_L2CAP` socket.
 
     .. versionadded:: next
 


### PR DESCRIPTION
Hi! Here are my suggestions for the docs of https://github.com/python/cpython/pull/129293. Merge this to update your PR.

- break out the tuple fields into a list, like `AF_TIPC` or `AF_CAN`
- define the referenced constants to avoid "missing target" warnings

(Ideally we'd merge allll the `socket` constant definitions with the usage documentation, so links go to informative text, but that's for a separate PR.)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--1.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->